### PR TITLE
Add speedtests

### DIFF
--- a/mcbackend/backends/clickhouse.py
+++ b/mcbackend/backends/clickhouse.py
@@ -103,6 +103,7 @@ class ClickHouseChain(Chain):
         *,
         client: clickhouse_driver.Client,
         insert_interval: int = 1,
+        insert_every: int = 500,
         draw_idx: int = 0,
     ):
         self._draw_idx = draw_idx
@@ -113,6 +114,7 @@ class ClickHouseChain(Chain):
         self._insert_queue = []
         self._last_insert = time.time()
         self._insert_interval = insert_interval
+        self._insert_every = insert_every
         super().__init__(cmeta, rmeta)
 
     def append(
@@ -126,7 +128,10 @@ class ClickHouseChain(Chain):
             self._insert_query = f"INSERT INTO {self.cid} ({names}) VALUES"
         self._insert_queue.append(params)
 
-        if time.time() - self._last_insert > self._insert_interval:
+        if (
+            len(self._insert_queue) >= self._insert_every
+            or time.time() - self._last_insert > self._insert_interval
+        ):
             self._commit()
         return
 

--- a/mcbackend/test_backend_clickhouse.py
+++ b/mcbackend/test_backend_clickhouse.py
@@ -7,17 +7,16 @@ import numpy
 import pandas
 import pytest
 
-from mcbackend.meta import ChainMeta, RunMeta, Variable
-
-from .backends.clickhouse import (
+from mcbackend.backends.clickhouse import (
     ClickHouseBackend,
     ClickHouseChain,
     ClickHouseRun,
     create_chain_table,
     create_runs_table,
 )
-from .core import Chain, Run, chain_id
-from .test_utils import CheckBehavior, make_runmeta
+from mcbackend.core import Chain, Run, chain_id
+from mcbackend.meta import ChainMeta, RunMeta, Variable
+from mcbackend.test_utils import CheckBehavior, CheckPerformance, make_runmeta
 
 try:
     client = clickhouse_driver.Client("localhost")
@@ -42,7 +41,7 @@ def fully_initialized(
     condition=not HAS_REAL_DB,
     reason="Integration tests need a ClickHouse server on localhost:9000 without authentication.",
 )
-class TestClickHouseBackend(CheckBehavior):
+class TestClickHouseBackend(CheckBehavior, CheckPerformance):
     cls_backend = ClickHouseBackend
     cls_run = ClickHouseRun
     cls_chain = ClickHouseChain
@@ -155,3 +154,9 @@ class TestClickHouseBackend(CheckBehavior):
         numpy.testing.assert_array_equal(v2, draw["v2"])
         numpy.testing.assert_array_equal(v3, draw["v3"])
         pass
+
+
+if __name__ == "__main__":
+    tc = TestClickHouseBackend()
+    df = tc.run_all_benchmarks()
+    print(df)

--- a/mcbackend/test_backend_numpy.py
+++ b/mcbackend/test_backend_numpy.py
@@ -3,14 +3,13 @@ import random
 import hagelkorn
 import numpy
 
+from mcbackend.backends.numpy import NumPyBackend, NumPyChain, NumPyRun
+from mcbackend.core import RunMeta
 from mcbackend.meta import Variable
-
-from .backends.numpy import NumPyBackend, NumPyChain, NumPyRun
-from .core import RunMeta
-from .test_utils import CheckBehavior
+from mcbackend.test_utils import CheckBehavior, CheckPerformance
 
 
-class TestNumPyBackend(CheckBehavior):
+class TestNumPyBackend(CheckBehavior, CheckPerformance):
     cls_backend = NumPyBackend
     cls_run = NumPyRun
     cls_chain = NumPyChain
@@ -77,3 +76,9 @@ class TestNumPyBackend(CheckBehavior):
         assert chain.get_draws("A").shape == (22, 2)
         assert chain.get_draws("B").shape == (22,)
         pass
+
+
+if __name__ == "__main__":
+    tc = TestNumPyBackend()
+    df = tc.run_all_benchmarks()
+    print(df)


### PR DESCRIPTION
I tried to include a test running multiple chains, but couldn't get the `multiprocessing.Pool` to work correctly.

Here are the results for the `ClickHouseBackend` with a server running locally in Docker:

| title | bytes_per_draw | append_speed | description |
| - | - | - | - |
| big_variables | 44400 | 10.9 MiB/s (257.3 draws/s) | One chain with 3 variables of shapes (100,), (1000,) and (100, 100). |
| many_draws | 56 | 1.1 MiB/s (21288.2 draws/s) | One chain of (), (3,) and (5,2) float32 variables. |
| many_variables | 3600 | 3.8 MiB/s (1116.0 draws/s) | One chain with 300 variables of shapes (), (3,) and (5,2). |