### PR TITLE
Add test and logging uneven chain lengths

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,7 @@ disable =
     C0116, # some methods are just too simple to deserve a docstring
     R0902, # too many instance attributes
     R0903, # too few public methods
+    R0912, # too many branches
     R0913, # too many arguments
     R0914, # too many local variables
     R1711, # useless return is okay

--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -20,4 +20,4 @@ except ModuleNotFoundError:
     pass
 
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
This is a follow-up to a5c1aae8944df94be2ecea63d4994181967b9879.

* It fixes a small bug where `clen` was overwritten,
* gives more detailed warning logs,
* and adds a test of the `.to_inferencedata(equalize_chain_lengths=...)` behavior.

Also, I'm bumping the version to `0.1.3`.