### PR TITLE
Add `slc` option to `Chain.get_draws` and `get_stats`

### DIFF
--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -20,4 +20,4 @@ except ModuleNotFoundError:
     pass
 
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"

--- a/mcbackend/backends/numpy.py
+++ b/mcbackend/backends/numpy.py
@@ -87,14 +87,14 @@ class NumPyChain(Chain):
     def __len__(self) -> int:
         return self._draw_idx
 
-    def get_draws(self, var_name: str) -> numpy.ndarray:
-        return self._samples[var_name][: self._draw_idx]
+    def get_draws(self, var_name: str, slc: slice = slice(None)) -> numpy.ndarray:
+        return self._samples[var_name][: self._draw_idx][slc]
 
     def get_draws_at(self, idx: int, var_names: Sequence[str]) -> Dict[str, numpy.ndarray]:
         return {vn: numpy.asarray(self._samples[vn][idx]) for vn in var_names}
 
-    def get_stats(self, stat_name: str) -> numpy.ndarray:
-        return self._stats[stat_name][: self._draw_idx]
+    def get_stats(self, stat_name: str, slc: slice = slice(None)) -> numpy.ndarray:
+        return self._stats[stat_name][: self._draw_idx][slc]
 
     def get_stats_at(self, idx: int, stat_names: Sequence[str]) -> Dict[str, numpy.ndarray]:
         return {sn: numpy.asarray(self._stats[sn][idx]) for sn in stat_names}

--- a/mcbackend/core.py
+++ b/mcbackend/core.py
@@ -70,12 +70,30 @@ class Chain(Sized):
         """
         raise NotImplementedError()
 
-    def get_draws(self, var_name: str) -> numpy.ndarray:
-        """Retrieve all draws of a variable from an MCMC chain."""
+    def get_draws(self, var_name: str, slc: slice = slice(None)) -> numpy.ndarray:
+        """Retrieve draws of a variable from an MCMC chain.
+
+        Parameters
+        ----------
+        var_name : str
+            Name of the variable.
+        slc : slice, optional
+            Optional ``slice`` object to retrieve only a subset of elements.
+            Passing this can be more performant than slicing the returned value.
+        """
         raise NotImplementedError()
 
-    def get_stats(self, stat_name: str) -> numpy.ndarray:
-        """Retrieve all values of a sampler statistic."""
+    def get_stats(self, stat_name: str, slc: slice = slice(None)) -> numpy.ndarray:
+        """Retrieve values of a sampler statistic.
+
+        Parameters
+        ----------
+        stat_name : str
+            Name of the stats variable.
+        slc : slice, optional
+            Optional ``slice`` object to retrieve only a subset of elements.
+            Passing this can be more performant than slicing the returned value.
+        """
         raise NotImplementedError()
 
     def get_draws_at(self, idx: int, var_names: Sequence[str]) -> Dict[str, numpy.ndarray]:


### PR DESCRIPTION
This PR adds a `slc` kwarg to the method signatures.
In a follow-up PR the implementations---particularly the `ClickHouseChain._get_rows` method---can be updated to make use of the `slc` information to select the data more efficiently (#50).

I added tests that assert that the `slc` functions in the same way as NumPy slicing the result manually.

Closes #47