### PR TITLE
Refactor `ClickHouseChain` for efficient slice selects

### DIFF
--- a/mcbackend/backends/clickhouse.py
+++ b/mcbackend/backends/clickhouse.py
@@ -177,9 +177,11 @@ class ClickHouseChain(Chain):
         data = self._client.execute(f"SELECT (`{var_name}`) FROM {self.cid};")
         draws = len(data)
 
-        # Safety checks
+        # Without draws return empty arrays of the correct shape/dtype
         if not draws:
-            raise Exception(f"No draws in chain {self.cid}.")
+            if is_rigid(nshape):
+                return numpy.empty(shape=[0] + nshape, dtype=dtype)
+            return numpy.array([], dtype=object)
 
         # The unpacking must also account for non-rigid shapes
         if is_rigid(nshape):
@@ -196,7 +198,7 @@ class ClickHouseChain(Chain):
             # To circumvent NumPy issue #19113
             arr = numpy.empty(draws, dtype=object)
             arr[:] = buffer
-            return arr
+            return arr[slc]
         # Otherwise (identical shapes) we can collapse into one ndarray
         return numpy.asarray(buffer, dtype=dtype)[slc]
 

--- a/mcbackend/test_backend_clickhouse.py
+++ b/mcbackend/test_backend_clickhouse.py
@@ -237,8 +237,10 @@ class TestClickHouseBackend(CheckBehavior, CheckPerformance):
         }
         chain = chains[0]
 
-        with pytest.raises(Exception, match="No draws in chain"):
-            chain._get_rows("v1", [], "uint16")
+        # Get empty vector from empty chain
+        nodraws = chain._get_rows("v1", [], "uint16")
+        assert nodraws.shape == (0,)
+        assert nodraws.dtype == numpy.uint16
 
         chain.append(draw)
         assert len(chain._insert_queue) == 1


### PR DESCRIPTION
* [x] Returning empty arrays (of correct shape and dtype) was needed because slices can result in an empty selection.
* [x] Increased coverage of the slicing test cases, including **empty slices**, **reverse direction slices** and **dynamically shaped variables**.
* [x] Implemented `WHERE` clause for the ClickHouse queries to download only the needed elements. This uses `>=`, `<` and a [`modulo`](https://clickhouse.com/docs/en/sql-reference/functions/arithmetic-functions/) operator.

The first CI run was ❌ just because of a too-low coverage.