### PR TITLE
Fix encoding/decoding of F-ordered NumPy arrays

### DIFF
--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -20,4 +20,4 @@ except ModuleNotFoundError:
     pass
 
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/mcbackend/npproto/__init__.py
+++ b/mcbackend/npproto/__init__.py
@@ -18,3 +18,4 @@ class Ndarray(betterproto.Message):
     dtype: str = betterproto.string_field(2)
     shape: List[int] = betterproto.int64_field(3)
     strides: List[int] = betterproto.int64_field(4)
+    order: str = betterproto.string_field(5)

--- a/mcbackend/test_npproto.py
+++ b/mcbackend/test_npproto.py
@@ -31,3 +31,15 @@ class TestUtils:
         result = utils.ndarray_to_numpy(dec)
         numpy.testing.assert_array_equal(result, arr)
         pass
+
+    @pytest.mark.parametrize("shape", [(5,), (2, 3), (2, 3, 5), (5, 2, 1, 7)])
+    @pytest.mark.parametrize("order", "CF")
+    def test_byteorders(self, shape, order):
+        arr = numpy.arange(numpy.prod(shape)).reshape(shape, order=order)
+
+        nda = utils.ndarray_from_numpy(arr)
+        assert nda.order == "CF"[arr.flags.f_contiguous]
+
+        dec = utils.ndarray_to_numpy(nda)
+        numpy.testing.assert_array_equal(arr, dec)
+        pass

--- a/protobufs/npproto/ndarray.proto
+++ b/protobufs/npproto/ndarray.proto
@@ -9,4 +9,5 @@ message ndarray {
     string dtype = 2;
     repeated int64 shape = 3;
     repeated int64 strides = 4;
+    string order = 5;
 }


### PR DESCRIPTION
The relevant details can be found in a code comment.

Closes #63