### PR TITLE
Give more informative errors for unsupported dtypes

### DIFF
--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -20,4 +20,4 @@ except ModuleNotFoundError:
     pass
 
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/mcbackend/backends/clickhouse.py
+++ b/mcbackend/backends/clickhouse.py
@@ -49,6 +49,11 @@ def create_runs_table(client: clickhouse_driver.Client):
 
 
 def column_spec_for(var: Variable, is_stat: bool = False):
+    if var.dtype not in CLICKHOUSE_DTYPES:
+        raise KeyError(
+            f"Don't know how to store dtype {var.dtype} "
+            f"of '{var.name}' (is_stat={is_stat}) in ClickHouse."
+        )
     cdt = CLICKHOUSE_DTYPES[var.dtype]
     ndim = len(var.shape)
     for _ in range(ndim):

--- a/mcbackend/test_backend_clickhouse.py
+++ b/mcbackend/test_backend_clickhouse.py
@@ -13,6 +13,7 @@ from mcbackend.backends.clickhouse import (
     ClickHouseBackend,
     ClickHouseChain,
     ClickHouseRun,
+    column_spec_for,
     create_chain_table,
 )
 from mcbackend.core import Run, chain_id
@@ -25,6 +26,16 @@ try:
     HAS_REAL_DB = True
 except:
     HAS_REAL_DB = False
+
+
+def test_column_spec_for():
+    assert column_spec_for(Variable("A", "float32", [])) == "`A` Float32"
+    assert column_spec_for(Variable("A", "float32", []), is_stat=True) == "`__stat_A` Float32"
+    assert column_spec_for(Variable("A", "float32", [2])) == "`A` Array(Float32)"
+    assert column_spec_for(Variable("A", "float32", [2, 3])) == "`A` Array(Array(Float32))"
+    with pytest.raises(KeyError, match="float16 of 'A'"):
+        column_spec_for(Variable("A", "float16", []))
+    pass
 
 
 def fully_initialized(


### PR DESCRIPTION
Helps to diagnose which variables or stats cause problems when initializing a `ClickHouseRun`.