### PR TITLE
Fix unsupported dtype from PyMC sampler warnings with `ClickHouseBackend`

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
         flake8 . --count --exit-zero --statistics
     - name: Test with pytest
       run: |
-        pytest --cov=./mcbackend --cov-report xml --cov-report term-missing mcbackend/
+        pytest -v --cov=./mcbackend --cov-report xml --cov-report term-missing mcbackend/
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       if: matrix.python-version == 3.9

--- a/mcbackend/backends/clickhouse.py
+++ b/mcbackend/backends/clickhouse.py
@@ -29,7 +29,7 @@ CLICKHOUSE_DTYPES = {
     "int64": "Int64",
     "float32": "Float32",
     "float64": "Float64",
-    "bool": "UInt8",
+    "bool": "Bool",
     "str": "String",
 }
 

--- a/mcbackend/backends/clickhouse.py
+++ b/mcbackend/backends/clickhouse.py
@@ -30,6 +30,7 @@ CLICKHOUSE_DTYPES = {
     "float32": "Float32",
     "float64": "Float64",
     "bool": "UInt8",
+    "str": "String",
 }
 
 
@@ -155,6 +156,7 @@ class ClickHouseChain(Chain):
         self._client = client
         # The following attributes belong to the batched insert mechanism.
         # Inserting in batches is much faster than inserting single rows.
+        self._str_cols = set()
         self._insert_query: str = ""
         self._insert_queue: List[Dict[str, Any]] = []
         self._last_insert = time.time()
@@ -166,12 +168,22 @@ class ClickHouseChain(Chain):
         self, draw: Dict[str, numpy.ndarray], stats: Optional[Dict[str, numpy.ndarray]] = None
     ):
         stat = {f"__stat_{sname}": svals for sname, svals in (stats or {}).items()}
-        params: Dict[str, Any] = {"_draw_idx": self._draw_idx, **draw, **stat}
-        self._draw_idx += 1
+        params: Dict[str, numpy.ndarray] = {**draw, **stat}
+
+        # On first append create a query to be used for the batched insert
         if not self._insert_query:
             names = "`,`".join(params.keys())
-            self._insert_query = f"INSERT INTO {self.cid} (`{names}`) VALUES"
+            self._insert_query = f"INSERT INTO {self.cid} (`_draw_idx`,`{names}`) VALUES"
+            self._str_cols = {k for k, v in params.items() if "str" in numpy.asarray(v).dtype.name}
+
+        # Convert str ndarrays to lists
+        for col in self._str_cols:
+            params[col] = params[col].tolist()
+
+        # Queue up for insertion
+        params["_draw_idx"] = self._draw_idx
         self._insert_queue.append(params)
+        self._draw_idx += 1
 
         if (
             len(self._insert_queue) >= self._insert_every
@@ -235,7 +247,9 @@ class ClickHouseChain(Chain):
             return numpy.array([], dtype=object)
 
         # The unpacking must also account for non-rigid shapes
-        if is_rigid(nshape):
+        # and str-dtyped empty arrays default to fixed length 1 strings.
+        # The [None] list is slower, but more flexible in this regard.
+        if is_rigid(nshape) and dtype != "str":
             assert nshape is not None
             buffer = numpy.empty((draws, *nshape), dtype)
         else:

--- a/mcbackend/test_adapter_pymc.py
+++ b/mcbackend/test_adapter_pymc.py
@@ -69,7 +69,6 @@ class TestPyMCAdapter:
         self._client_main.disconnect()
         return
 
-    @pytest.mark.xfail(reason="Warning stats are objects. See #73.")
     @pytest.mark.parametrize("cores", [1, 3])
     def test_cores(self, simple_model, cores):
         backend = ClickHouseBackend(self._client)

--- a/mcbackend/test_adapter_pymc.py
+++ b/mcbackend/test_adapter_pymc.py
@@ -69,6 +69,7 @@ class TestPyMCAdapter:
         self._client_main.disconnect()
         return
 
+    @pytest.mark.xfail(reason="Warning stats are objects. See #73.")
     @pytest.mark.parametrize("cores", [1, 3])
     def test_cores(self, simple_model, cores):
         backend = ClickHouseBackend(self._client)
@@ -87,13 +88,11 @@ class TestPyMCAdapter:
             trace = TraceBackend(backend)
             idata = pm.sample(
                 trace=trace,
-                tune=3,
-                draws=5,
+                tune=30,
+                draws=50,
                 chains=2,
                 cores=cores,
-                step=pm.Metropolis(),
                 discard_tuned_samples=False,
-                compute_convergence_checks=False,
             )
         if not len(args) == 1:
             _log.warning("Run was initialized multiple times.")
@@ -101,9 +100,9 @@ class TestPyMCAdapter:
 
         # Chain lenghts after conversion
         assert idata.posterior.dims["chain"] == 2
-        assert idata.posterior.dims["draw"] == 5
+        assert idata.posterior.dims["draw"] == 50
         assert idata.warmup_posterior.dims["chain"] == 2
-        assert idata.warmup_posterior.dims["draw"] == 3
+        assert idata.warmup_posterior.dims["draw"] == 30
 
         # Tracking of named variable dimensions
         vars = {var.name: var for var in rmeta.variables}

--- a/mcbackend/test_adapter_pymc.py
+++ b/mcbackend/test_adapter_pymc.py
@@ -11,7 +11,7 @@ from mcbackend.npproto.utils import ndarray_to_numpy
 
 from .adapters.pymc import TraceBackend, find_data
 from .backends.clickhouse import ClickHouseBackend
-from .test_backend_clickhouse import HAS_REAL_DB
+from .test_backend_clickhouse import DB_KWARGS, HAS_REAL_DB
 
 _log = logging.getLogger(__file__)
 
@@ -57,9 +57,9 @@ class TestPyMCAdapter:
     def setup_method(self, method):
         """Initializes a fresh database just for this test method."""
         self._db = "testing_" + hagelkorn.random()
-        self._client_main = clickhouse_driver.Client("localhost")
+        self._client_main = clickhouse_driver.Client(**DB_KWARGS)
         self._client_main.execute(f"CREATE DATABASE {self._db};")
-        self._client = clickhouse_driver.Client("localhost", database=self._db)
+        self._client = clickhouse_driver.Client(**DB_KWARGS, database=self._db)
         self.backend = ClickHouseBackend(self._client)
         return
 

--- a/mcbackend/test_backend_clickhouse.py
+++ b/mcbackend/test_backend_clickhouse.py
@@ -202,7 +202,7 @@ class TestClickHouseBackend(CheckBehavior, CheckPerformance):
             ("scalar", "UInt16"),
             ("1D", "Array(Float32)"),
             ("3D", "Array(Array(Array(Float64)))"),
-            ("__stat_accepted", "UInt8"),
+            ("__stat_accepted", "Bool"),
         ]
         pass
 

--- a/mcbackend/test_backend_clickhouse.py
+++ b/mcbackend/test_backend_clickhouse.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Sequence, Tuple
 
@@ -21,7 +22,11 @@ from mcbackend.meta import ChainMeta, RunMeta, Variable
 from mcbackend.test_utils import CheckBehavior, CheckPerformance, make_runmeta
 
 try:
-    client = clickhouse_driver.Client("localhost")
+    DB_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
+    DB_PASS = os.environ.get("CLICKHOUSE_PASS", "")
+    DB_PORT = os.environ.get("CLICKHOUSE_PORT", 9000)
+    DB_KWARGS = dict(host=DB_HOST, port=DB_PORT, password=DB_PASS)
+    client = clickhouse_driver.Client(**DB_KWARGS)
     client.execute("SHOW DATABASES;")
     HAS_REAL_DB = True
 except:
@@ -51,7 +56,7 @@ def fully_initialized(
 
 @pytest.mark.skipif(
     condition=not HAS_REAL_DB,
-    reason="Integration tests need a ClickHouse server on localhost:9000 without authentication.",
+    reason="Integration tests need a ClickHouse server.",
 )
 class TestClickHouseBackendInitialization:
     """This is separate because ``TestClickHouseBackend.setup_method`` depends on these things."""
@@ -63,12 +68,12 @@ class TestClickHouseBackendInitialization:
 
     def test_backend_from_client_object(self):
         db = "testing_" + hagelkorn.random()
-        _client_main = clickhouse_driver.Client("localhost")
+        _client_main = clickhouse_driver.Client(**DB_KWARGS)
         _client_main.execute(f"CREATE DATABASE {db};")
 
         try:
             # When created from a client object, all chains share the client
-            backend = ClickHouseBackend(client=clickhouse_driver.Client("localhost", database=db))
+            backend = ClickHouseBackend(client=clickhouse_driver.Client(**DB_KWARGS, database=db))
             assert callable(backend._client_fn)
             run = backend.init_run(make_runmeta())
             c1 = run.init_chain(0)
@@ -81,11 +86,11 @@ class TestClickHouseBackendInitialization:
 
     def test_backend_from_client_function(self):
         db = "testing_" + hagelkorn.random()
-        _client_main = clickhouse_driver.Client("localhost")
+        _client_main = clickhouse_driver.Client(**DB_KWARGS)
         _client_main.execute(f"CREATE DATABASE {db};")
 
         def client_fn():
-            return clickhouse_driver.Client("localhost", database=db)
+            return clickhouse_driver.Client(**DB_KWARGS, database=db)
 
         try:
             # When created from a client function, each chain has its own client
@@ -108,7 +113,7 @@ class TestClickHouseBackendInitialization:
 
 @pytest.mark.skipif(
     condition=not HAS_REAL_DB,
-    reason="Integration tests need a ClickHouse server on localhost:9000 without authentication.",
+    reason="Integration tests need a ClickHouse server.",
 )
 class TestClickHouseBackend(CheckBehavior, CheckPerformance):
     cls_backend = ClickHouseBackend
@@ -118,11 +123,11 @@ class TestClickHouseBackend(CheckBehavior, CheckPerformance):
     def setup_method(self, method):
         """Initializes a fresh database just for this test method."""
         self._db = "testing_" + hagelkorn.random()
-        self._client_main = clickhouse_driver.Client("localhost")
+        self._client_main = clickhouse_driver.Client(**DB_KWARGS)
         self._client_main.execute(f"CREATE DATABASE {self._db};")
-        self._client = clickhouse_driver.Client("localhost", database=self._db)
+        self._client = clickhouse_driver.Client(**DB_KWARGS, database=self._db)
         self.backend = ClickHouseBackend(
-            client_fn=lambda: clickhouse_driver.Client("localhost", database=self._db)
+            client_fn=lambda: clickhouse_driver.Client(**DB_KWARGS, database=self._db)
         )
         return
 


### PR DESCRIPTION
This MR fixes some incompatibilities with `NUTS` sampling on recent PyMC versions.

### Background
Since [PyMC v4.3.0](https://github.com/pymc-devs/pymc/releases/tag/v4.3.0) or more specifically since https://github.com/pymc-devs/pymc/pull/6192, the `SamplerWarning`s emitted by some step methods --- most importantly `NUTS` --- are no longer collected on the PyMC `BaseTrace` object, but rather as any other sampler stat.

This created an incompatibility with McBackend, where the `ClickHouseBackend` could not store these `object`-dtyped things into the database.

### Solution
Instead of filtering/ignoring the `"warning"` stat, I went all the way to actually support storing it by pickling it, base64-encoding the bytes and storing the base64 encoded data as an ASCII string.

For this, the following changes were needed:
* Supporting the storage of `str` dtypes in the `NumPyBackend` and `ClickHouseBackend`.
* Tweaking the `mcbackend.adapters.pymc.TraceBackend` to encode/decode the `"warning"` stat such that the `mcbackend.Chain` only sees `str` data coming in/out.
* Running the PyMC integration test with `NUTS` to provoke needing to store `SamplerWarning`.

Further changes along the way:
* Parametrizing tests to connect to ClickHouse servers other than `"localhost"`, via `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT` and `CLICKHOUSE_PASS` environment variables.
* Small refactors to adapt to changes in the PyMC API.
* A test for #74 was added.
* Storing `bool` data as the ClickHouse `Bool` type, which was not supported with earlier versions.
