### PR TITLE
Use -1 to indicate dynamically sized dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ docker run --detach --rm --name mcbackend-db -p 9000:9000 --ulimit nofile=262144
 If you don't already have it, first install the protobuf compiler:
 ```bash
 conda install protobuf
+pip install --pre "betterproto[compiler]"
 ```
 
 To compile the `*.proto` files for languages other than Python, check the [ProtocolBuffers documentation](https://developers.google.com/protocol-buffers/docs/tutorials).

--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -12,12 +12,4 @@ try:
 except ModuleNotFoundError:
     pass
 
-# Adapters
-try:
-    from .adapters import pymc
-    from .adapters.pymc import TraceBackend
-except ModuleNotFoundError:
-    pass
-
-
 __version__ = "0.4.0"

--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -20,4 +20,4 @@ except ModuleNotFoundError:
     pass
 
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/mcbackend/core.py
+++ b/mcbackend/core.py
@@ -32,12 +32,12 @@ def is_rigid(nshape: Optional[Shape]):
         This "nullable shape" is interpreted as follows:
         - ``[]`` indicates scalar shape (rigid: True).
         - ``[2, 3]`` indicates a matrix with 2 rows and 3 columns (rigid: True).
-        - ``[2, 0]`` indicates a matrix with 2 rows and dynamic number of columns (rigid: False).
+        - ``[2, -1]`` indicates a matrix with 2 rows and dynamic number of columns (rigid: False).
         - ``None`` indicates dynamic dimensionality (rigid: False).
     """
     if nshape is None:
         return False
-    if any(s == 0 for s in nshape):
+    if any(s == -1 for s in nshape):
         return False
     return True
 

--- a/mcbackend/meta.py
+++ b/mcbackend/meta.py
@@ -32,7 +32,7 @@ class Variable(betterproto.Message):
     dtype: str = betterproto.string_field(2)
     """Data type (lowercase)."""
 
-    shape: List[int] = betterproto.uint64_field(3)
+    shape: List[int] = betterproto.int64_field(3)
     """
     The shape tuple. May contain 0es for dynamically sized dimensions. The
     default value, an empty sequence, corresponds to scalar shape. Note that

--- a/mcbackend/test_backend_numpy.py
+++ b/mcbackend/test_backend_numpy.py
@@ -21,7 +21,7 @@ class TestNumPyBackend(CheckBehavior, CheckPerformance):
             variables=[
                 Variable("tensor", "int8", (3, 4, 5)),
                 Variable("scalar", "float64", ()),
-                Variable("changeling", "uint16", (3, 0)),
+                Variable("changeling", "uint16", (3, -1)),
             ],
         )
         run = imb.init_run(rm)
@@ -56,7 +56,7 @@ class TestNumPyBackend(CheckBehavior, CheckPerformance):
                 Variable(
                     "B",
                     "float32",
-                    (0,),
+                    (-1,),
                 ),
             ],
         )

--- a/mcbackend/test_core.py
+++ b/mcbackend/test_core.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
 
 import numpy
-import pytest
 
 from mcbackend.meta import ChainMeta, RunMeta, Variable
 from mcbackend.test_utils import make_runmeta
@@ -12,9 +11,10 @@ from . import core
 def test_is_rigid():
     assert core.is_rigid([])
     assert core.is_rigid([1, 2])
+    assert core.is_rigid([1, 0])
     assert not core.is_rigid(None)
-    assert not core.is_rigid((0,))
-    assert not core.is_rigid([1, 0, 2])
+    assert not core.is_rigid((-1,))
+    assert not core.is_rigid([1, -1, 2])
     pass
 
 

--- a/mcbackend/test_utils.py
+++ b/mcbackend/test_utils.py
@@ -57,7 +57,7 @@ def make_draw(variables: Sequence[Variable]):
     for var in variables:
         dshape = tuple(
             # A pre-registered dim length of 0 means that it's random!
-            s or random.randint(0, 10)
+            (random.randint(0, 10) if s == -1 else s)
             for s in var.shape
         )
         if "float" in var.dtype:
@@ -215,7 +215,7 @@ class CheckBehavior(BaseBackendTest):
         # "B" are dynamically shaped to cover the edge cases.
         rmeta = RunMeta(
             variables=[Variable("A", "uint8"), Variable("M", "str", [2, 3])],
-            sample_stats=[Variable("B", "uint8", [2, 0])],
+            sample_stats=[Variable("B", "uint8", [2, -1])],
             data=[],
         )
         run = self.backend.init_run(rmeta)

--- a/protobufs/meta.proto
+++ b/protobufs/meta.proto
@@ -25,7 +25,7 @@ message Variable {
     // The default value, an empty sequence, corresponds to scalar shape.
     // Note that for variables of dynamic dimensionality, ``undefined_ndim=True``
     // can be set to render ``shape`` and ``dims`` meaningless.
-    repeated uint64 shape = 3;
+    repeated int64 shape = 3;
     // Names of the variable's dimensions.
     // The default value, an empty sequence, corresponds to undefined dimension names
     // and applies to scalar variables, and variables where ``undefined_ndim=True``.


### PR DESCRIPTION
Strictly speaking the change of data type in the protobuf is bad practice, but the package is still in `0.x` versions so there's that.