### PR TITLE
Add public variables to __all__ in main __init__.py

### DIFF
--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -13,3 +13,17 @@ except ModuleNotFoundError:
     pass
 
 __version__ = "0.5.0"
+__all__ = [
+    "NumPyBackend",
+    "Backend",
+    "Chain",
+    "Run",
+    "ChainMeta",
+    "Coordinate",
+    "DataVariable",
+    "ExtendedValue",
+    "RunMeta",
+    "Variable",
+    "clickhouse",
+    "ClickHouseBackend",
+]


### PR DESCRIPTION
Hiya,

I was poking around in pymc's typing, and came across this type error:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/2721423/236770787-f5ad79e8-9a06-4225-b96f-18376224ab99.png">

This is due to variables imported in `__init__,py` being "private" by default. The alternatives are either adding them under `__all__` like I have done here (explicitly defining public variables) or importing them using `as`, for instance `from .core import Backend as Backend`. Since there are several variables, I chose the former.

You can read more in this [documentation](https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface) and this [issue](https://github.com/microsoft/pylance-release/issues/2953).